### PR TITLE
Ensure Vercel deploy includes static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ npm start
 4. **Deploy automático** será feito
 5. **Acesse** a URL fornecida pela Vercel
 
+> ℹ️ O arquivo `vercel.json` inclui os diretórios `css`, `js`, `fonts`, `images` e `media`, garantindo que os arquivos estáticos sejam enviados no deploy.
+
 ## 🔧 Configuração
 
 ### Credenciais SyncPay

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,19 @@
 {
   "version": 2,
   "name": "checkout-syncpay",
-  "builds": [
-    {
-      "src": "server.js",
-      "use": "@vercel/node"
+  "functions": {
+    "server.js": {
+      "runtime": "nodejs18.x",
+      "includeFiles": [
+        "index.html",
+        "css/**",
+        "js/**",
+        "fonts/**",
+        "images/**",
+        "media/**"
+      ]
     }
-  ],
+  },
   "routes": [
     {
       "src": "/(.*)",


### PR DESCRIPTION
## Summary
- Include static directories and index.html via `includeFiles` in `vercel.json`
- Document static asset inclusion for Vercel deploy in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b61ba26f60832a9f961ad662c4ef91