### PR TITLE
Fix proxy endpoint paths

### DIFF
--- a/INSTRUCOES-TESTE.md
+++ b/INSTRUCOES-TESTE.md
@@ -67,7 +67,7 @@ npm start
 🚀 Servidor rodando na porta 3000
 📱 Acesse: http://localhost:3000
 🔧 Proxy SyncPay: http://localhost:3000/api/syncpay
-[PROXY] POST /auth-token -> /api/partner/v1/auth-token
+[PROXY] POST /auth-token -> /partner/v1/auth-token
 [PROXY] Resposta: 200
 ```
 

--- a/README-DEBUG.md
+++ b/README-DEBUG.md
@@ -81,7 +81,7 @@ O servidor agora inclui:
 ### Logs do Servidor
 O servidor mostra logs detalhados:
 ```
-[PROXY] POST /auth-token -> /api/partner/v1/auth-token
+[PROXY] POST /auth-token -> /partner/v1/auth-token
 [PROXY] Resposta: 200
 ```
 

--- a/public/js/syncpay-integration.js
+++ b/public/js/syncpay-integration.js
@@ -20,10 +20,10 @@ class SyncPayIntegration {
     async getAuthToken() {
         this.log('🔐 [DEBUG] Iniciando autenticação com SyncPay...');
         try {
-            this.log('📡 [DEBUG] Fazendo requisição para:', `${this.config.base_url}/api/partner/v1/auth-token`);
+            this.log('📡 [DEBUG] Fazendo requisição para:', `${this.config.base_url}/partner/v1/auth-token`);
             this.log('🔑 [DEBUG] Credenciais:', { client_id: this.config.client_id, client_secret: '***' });
             
-            const response = await fetch(`${this.config.base_url}/api/partner/v1/auth-token`, {
+            const response = await fetch(`${this.config.base_url}/partner/v1/auth-token`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -111,11 +111,11 @@ class SyncPayIntegration {
                 ]
             };
             
-            this.log('📡 [DEBUG] Fazendo requisição PIX para:', `${this.config.base_url}/api/partner/v1/cash-in`);
+            this.log('📡 [DEBUG] Fazendo requisição PIX para:', `${this.config.base_url}/partner/v1/cash-in`);
             this.log('📦 [DEBUG] Dados da requisição:', requestBody);
 
             // Criar transação PIX
-            const response = await fetch(`${this.config.base_url}/api/partner/v1/cash-in`, {
+            const response = await fetch(`${this.config.base_url}/partner/v1/cash-in`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -249,9 +249,9 @@ class SyncPayIntegration {
                     await this.getAuthToken();
                 }
 
-                this.log('📡 [DEBUG] Fazendo requisição de status para:', `${this.config.base_url}/api/partner/v1/transactions/${transactionId}`);
+                this.log('📡 [DEBUG] Fazendo requisição de status para:', `${this.config.base_url}/partner/v1/transactions/${transactionId}`);
 
-                const response = await fetch(`${this.config.base_url}/api/partner/v1/transactions/${transactionId}`, {
+                const response = await fetch(`${this.config.base_url}/partner/v1/transactions/${transactionId}`, {
                     headers: {
                         'Authorization': `Bearer ${this.authToken}`
                     }


### PR DESCRIPTION
## Summary
- remove duplicate `/api` segment from frontend proxy requests
- update documentation examples to match new proxy URL

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b61eeb5a08832aa1b419878b0908fc