### PR TITLE
Add auth proxy server using Express for SyncPayments auth

### DIFF
--- a/authProxyServer.js
+++ b/authProxyServer.js
@@ -1,0 +1,31 @@
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Middleware para interpretar JSON
+app.use(express.json());
+
+// Endpoint local que atua como proxy
+app.post('/api/auth-token', async (req, res) => {
+  try {
+    const response = await fetch('https://api.syncpayments.com.br/api/partner/v1/auth-token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(req.body)
+    });
+
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (error) {
+    console.error('[Auth Proxy] Erro ao obter token:', error);
+    res.status(500).json({ error: 'Erro ao autenticar com a API SyncPayments' });
+  }
+});
+
+// Inicia o servidor na porta 3000
+app.listen(PORT, () => {
+  console.log(`Servidor de proxy de autenticação rodando na porta ${PORT}`);
+});

--- a/public/js/authProxyClient.js
+++ b/public/js/authProxyClient.js
@@ -1,0 +1,34 @@
+// Função para obter token de autenticação via proxy local
+async function fetchAuthToken() {
+  const payload = {
+    client_id: window.SYNCPAY_CONFIG?.client_id || '',
+    client_secret: window.SYNCPAY_CONFIG?.client_secret || '',
+    '01K1259MAXE0TNRXV2C2WQN2MV': 'valor'
+  };
+
+  try {
+    const response = await fetch('/api/auth-token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Erro na requisição: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log('Access token:', data.access_token);
+    return data.access_token;
+  } catch (error) {
+    console.error('Erro ao obter token:', error);
+  }
+}
+
+// Torna a função disponível globalmente
+window.fetchAuthToken = fetchAuthToken;
+
+// Exemplo de uso em um botão com id "authButton"
+document.getElementById('authButton')?.addEventListener('click', fetchAuthToken);


### PR DESCRIPTION
## Summary
- add minimal Express server exposing `/api/auth-token` that proxies to SyncPayments auth endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6291dabf0832a8a124d8c790589fb