### PR TITLE
Add auth token button and config script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1030,6 +1030,14 @@ $(document).ready(function() {
 
     
 </script>
+<button id="authButton">Obter Token</button>
+<script>
+  window.SYNCPAY_CONFIG = {
+    client_id: "fixed-client-id",
+    client_secret: "fixed-client-secret"
+  };
+</script>
+<script src="js/authProxyClient.js"></script>
     
     
 


### PR DESCRIPTION
## Summary
- add “Obter Token” button with id `authButton`
- define `window.SYNCPAY_CONFIG` with fixed credentials
- load `js/authProxyClient.js` on the page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b62e0a3634832a98fa6ce64614cdf3