### PR TITLE
Add plan validation and fallback config

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -739,7 +739,12 @@ $(document).ready(function() {
         
         syncPay.showLoading();
         
-        const plan = window.SYNCPAY_CONFIG.plans.monthly;
+        const plans = window.SYNCPAY_CONFIG?.plans;
+        if (!plans?.monthly) {
+            console.error('Plano mensal não configurado em SYNCPAY_CONFIG');
+            return;
+        }
+        const plan = plans.monthly;
         const transaction = await syncPay.createPixTransaction(plan.price, plan.description);
         
         if (typeof swal !== 'undefined') {
@@ -768,7 +773,12 @@ $(document).ready(function() {
         
         syncPay.showLoading();
         
-        const plan = window.SYNCPAY_CONFIG.plans.quarterly;
+        const plans = window.SYNCPAY_CONFIG?.plans;
+        if (!plans?.quarterly) {
+            console.error('Plano trimestral não configurado em SYNCPAY_CONFIG');
+            return;
+        }
+        const plan = plans.quarterly;
         const transaction = await syncPay.createPixTransaction(plan.price, plan.description);
         
         if (typeof swal !== 'undefined') {
@@ -797,7 +807,12 @@ $(document).ready(function() {
         
         syncPay.showLoading();
         
-        const plan = window.SYNCPAY_CONFIG.plans.biannual;
+        const plans = window.SYNCPAY_CONFIG?.plans;
+        if (!plans?.biannual) {
+            console.error('Plano semestral não configurado em SYNCPAY_CONFIG');
+            return;
+        }
+        const plan = plans.biannual;
         const transaction = await syncPay.createPixTransaction(plan.price, plan.description);
         
         if (typeof swal !== 'undefined') {
@@ -1031,12 +1046,19 @@ $(document).ready(function() {
     
 </script>
 <button id="authButton">Obter Token</button>
-<script>
-  window.SYNCPAY_CONFIG = {
-    client_id: "fixed-client-id",
-    client_secret: "fixed-client-secret"
-  };
-</script>
+  <script>
+    window.SYNCPAY_CONFIG = window.SYNCPAY_CONFIG || {};
+    window.SYNCPAY_CONFIG.client_id = window.SYNCPAY_CONFIG.client_id || "fixed-client-id";
+    window.SYNCPAY_CONFIG.client_secret = window.SYNCPAY_CONFIG.client_secret || "fixed-client-secret";
+    if (!window.SYNCPAY_CONFIG.plans) {
+      window.SYNCPAY_CONFIG.plans = {
+        monthly: {
+          price: 0,
+          description: 'Plano mensal de exemplo'
+        }
+      };
+    }
+  </script>
 <script src="js/authProxyClient.js"></script>
     
     


### PR DESCRIPTION
## Summary
- guard PIX plan buttons against missing SyncPay configuration
- ensure `window.SYNCPAY_CONFIG` retains plans and add sample monthly plan if absent

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b63027dd70832a8f93fb439306c88d