### PR TITLE
feat: add Pix plan button handlers

### DIFF
--- a/public/js/config.js
+++ b/public/js/config.js
@@ -19,7 +19,7 @@ const SYNCPAY_CONFIG = {
             price: 59.70,
             description: 'Assinatura 3 meses - Stella Beghini'
         },
-        biannual: {
+        semestrial: {
             price: 119.40,
             description: 'Assinatura 6 meses - Stella Beghini'
         }

--- a/public/js/pix-plan-buttons.js
+++ b/public/js/pix-plan-buttons.js
@@ -1,0 +1,39 @@
+(function($){
+    function attachPlanHandler(buttonId, planKey){
+        $(buttonId).on('click', async function(){
+            if (!window.syncPay) {
+                alert('Serviço de pagamento indisponível.');
+                return;
+            }
+
+            const plans = window.SYNCPAY_CONFIG && window.SYNCPAY_CONFIG.plans;
+            const plan = plans && plans[planKey];
+            if (!plan) {
+                alert('Plano não encontrado.');
+                return;
+            }
+
+            try {
+                window.syncPay.showLoading();
+                const transaction = await window.syncPay.createPixTransaction(plan.price, plan.description);
+                $(this).data('pixTransaction', transaction);
+                alert('PIX gerado com sucesso!');
+            } catch (err) {
+                console.error(err);
+                alert('Erro ao gerar PIX.');
+            } finally {
+                if (typeof swal !== 'undefined') {
+                    swal.close();
+                } else {
+                    $('#nativeLoading').remove();
+                }
+            }
+        });
+    }
+
+    $(function(){
+        attachPlanHandler('#btn-1-mes', 'monthly');
+        attachPlanHandler('#btn-3-meses', 'quarterly');
+        attachPlanHandler('#btn-6-meses', 'semestrial');
+    });
+})(jQuery);


### PR DESCRIPTION
## Summary
- add modular jQuery handlers for PIX subscription buttons
- rename biannual plan to semestrial in SYNCPAY config

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b631a6a4dc832aa48e242dc93063f5