### PR TITLE
Reorder QR and PIX display in modal and keep copy code on one line

### DIFF
--- a/public/css/payment-modal.css
+++ b/public/css/payment-modal.css
@@ -229,7 +229,9 @@
     margin-bottom: 15px;
     font-family: 'Courier New', monospace;
     font-size: 12px;
-    word-break: break-all;
+    white-space: nowrap;
+    overflow-x: auto;
+    word-break: normal;
     color: #666;
     line-height: 1.4;
 }

--- a/public/js/payment-modal.js
+++ b/public/js/payment-modal.js
@@ -61,6 +61,12 @@ class PaymentModal {
                     <p class="payment-plan-price" id="paymentPlanPrice">R$ 15,00</p>
                 </div>
                 
+                <div class="payment-qr-container" id="paymentQRContainer">
+                    <div class="payment-qr-code" id="paymentQRCode">
+                        <!-- QR Code será inserido aqui -->
+                    </div>
+                </div>
+
                 <div class="payment-pix">
                     <p class="payment-pix-label">CHAVE PIX</p>
                     <div class="payment-pix-code" id="paymentPixCode">
@@ -69,12 +75,6 @@ class PaymentModal {
                     <button class="payment-copy-button" id="paymentCopyButton">
                         COPIAR CHAVE PIX
                     </button>
-                </div>
-                
-                <div class="payment-qr-container" id="paymentQRContainer">
-                    <div class="payment-qr-code" id="paymentQRCode">
-                        <!-- QR Code será inserido aqui -->
-                    </div>
                 </div>
                 
                 <div class="payment-status" id="paymentStatus">
@@ -162,6 +162,8 @@ class PaymentModal {
                 pixCode = 'Código PIX será gerado em breve...';
             }
 
+            // Garantir que o código PIX esteja em uma única linha
+            pixCode = pixCode.replace(/\r?\n|\r/g, '').trim();
             pixCodeElement.textContent = pixCode;
 
             // Habilitar/desabilitar botão de copiar


### PR DESCRIPTION
## Summary
- Show QR code above PIX key in payment modal
- Prevent PIX code from breaking lines and strip newline characters

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b70e4281c8832a9bad8cb71691224f