### PR TITLE
Add spacing between main image and reflection

### DIFF
--- a/public/css/shadow-styles.css
+++ b/public/css/shadow-styles.css
@@ -2062,11 +2062,14 @@
   #conteudo-postagens .videopostagem img.media-principal { /* Adicione a classe 'media-principal' à sua <img> */
       width: 100%;
       height: 100%;
-      
+
       /* ESSA É A MÁGICA:
         'cover' preenche o espaço mantendo a proporção, cortando o excesso.
         Isso remove as barras pretas e a distorção. */
-      object-fit: cover; 
+      object-fit: cover;
+
+      /* Adiciona uma separação entre a imagem principal e sua reflexão */
+      -webkit-box-reflect: below 10px linear-gradient(transparent, rgba(0,0,0,0.2));
   }
 
   /* 3. Ajustes para o overlay não atrapalhar */


### PR DESCRIPTION
## Summary
- Add 10px gap between profile header image and its reflection using `-webkit-box-reflect`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b71c6263bc832aa36aafdea1f31bc7