### PR TITLE
Fix pix generation to use selected gateway

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -736,217 +736,10 @@ $(document).ready(function() {
         $(this).addClass('active');
     });
 
-    // NOVOS BOTÕES DE PAGAMENTO COM PIX
-    $('#btn-1-mes').on('click', async function() {
-        try {
-            if (!window.syncPay) {
-                console.error('SyncPay não inicializado');
-                alert('Sistema de pagamento não está disponível. Tente novamente em alguns segundos.');
-                return;
-            }
-            
-            syncPay.showLoading();
-            
-            const plans = window.SYNCPAY_CONFIG?.plans;
-            if (!plans?.monthly) {
-                console.error('Plano mensal não configurado em SYNCPAY_CONFIG');
-                alert('Plano mensal não está configurado. Entre em contato com o suporte.');
-                return;
-            }
-            const plan = plans.monthly;
-            
-            // Dados do cliente - deve ser coletado de um formulário real
-            const clientData = {
-                name: 'Cliente', // Substituir por dados reais do cliente
-                cpf: '12345678901', // Substituir por CPF real do cliente
-                email: 'cliente@exemplo.com', // Substituir por email real do cliente
-                phone: '11999999999' // Substituir por telefone real do cliente
-            };
-            
-            const transaction = await syncPay.createPixTransaction(plan.price, plan.description, clientData);
-            
-            // Fechar loading
-            if (typeof swal !== 'undefined') {
-                try {
-                    swal.close();
-                } catch (error) {
-                    console.warn('Erro ao fechar SweetAlert:', error);
-                }
-            } else {
-                // Remover loading nativo se existir
-                const nativeLoading = document.getElementById('nativeLoading');
-                if (nativeLoading) {
-                    nativeLoading.remove();
-                }
-            }
-            
-            if (transaction) {
-                syncPay.showPixModal({
-                    pix_code: transaction.pix_code,
-                    amount: plan.price,
-                    id: transaction.id
-                });
-            }
-        } catch (error) {
-            console.error('Erro ao processar pagamento:', error);
-            
-            // Fechar loading em caso de erro
-            if (typeof swal !== 'undefined') {
-                try {
-                    swal.close();
-                } catch (e) {
-                    console.warn('Erro ao fechar SweetAlert:', e);
-                }
-            } else {
-                const nativeLoading = document.getElementById('nativeLoading');
-                if (nativeLoading) {
-                    nativeLoading.remove();
-                }
-            }
-            
-            alert('Erro ao processar pagamento: ' + error.message);
-        }
-    });
+    // BOTÕES DE PAGAMENTO COM PIX - MOVIDOS PARA pix-plan-buttons.js
+    // Os handlers agora estão no arquivo js/pix-plan-buttons.js com integração universal
 
-    $('#btn-3-meses').on('click', async function() {
-        try {
-            if (!window.syncPay) {
-                console.error('SyncPay não inicializado');
-                alert('Sistema de pagamento não está disponível. Tente novamente em alguns segundos.');
-                return;
-            }
-            
-            syncPay.showLoading();
-            
-            const plans = window.SYNCPAY_CONFIG?.plans;
-            if (!plans?.quarterly) {
-                console.error('Plano trimestral não configurado em SYNCPAY_CONFIG');
-                alert('Plano trimestral não está configurado. Entre em contato com o suporte.');
-                return;
-            }
-            const plan = plans.quarterly;
-            
-            // Dados do cliente - deve ser coletado de um formulário real
-            const clientData = {
-                name: 'Cliente', // Substituir por dados reais do cliente
-                cpf: '12345678901', // Substituir por CPF real do cliente
-                email: 'cliente@exemplo.com', // Substituir por email real do cliente
-                phone: '11999999999' // Substituir por telefone real do cliente
-            };
-            
-            const transaction = await syncPay.createPixTransaction(plan.price, plan.description, clientData);
-            
-            // Fechar loading
-            if (typeof swal !== 'undefined') {
-                try {
-                    swal.close();
-                } catch (error) {
-                    console.warn('Erro ao fechar SweetAlert:', error);
-                }
-            } else {
-                const nativeLoading = document.getElementById('nativeLoading');
-                if (nativeLoading) {
-                    nativeLoading.remove();
-                }
-            }
-            
-            if (transaction) {
-                syncPay.showPixModal({
-                    pix_code: transaction.pix_code,
-                    amount: plan.price,
-                    id: transaction.id
-                });
-            }
-        } catch (error) {
-            console.error('Erro ao processar pagamento:', error);
-            
-            // Fechar loading em caso de erro
-            if (typeof swal !== 'undefined') {
-                try {
-                    swal.close();
-                } catch (e) {
-                    console.warn('Erro ao fechar SweetAlert:', e);
-                }
-            } else {
-                const nativeLoading = document.getElementById('nativeLoading');
-                if (nativeLoading) {
-                    nativeLoading.remove();
-                }
-            }
-            
-            alert('Erro ao processar pagamento: ' + error.message);
-        }
-    });
-
-    $('#btn-6-meses').on('click', async function() {
-        try {
-            if (!window.syncPay) {
-                console.error('SyncPay não inicializado');
-                alert('Sistema de pagamento não está disponível. Tente novamente em alguns segundos.');
-                return;
-            }
-            
-            syncPay.showLoading();
-            
-            const plans = window.SYNCPAY_CONFIG?.plans;
-            if (!plans?.semestrial) {
-                console.error('Plano semestral não configurado em SYNCPAY_CONFIG');
-                alert('Plano semestral não está configurado. Entre em contato com o suporte.');
-                return;
-            }
-            const plan = plans.semestrial;
-            
-            // Dados do cliente - deve ser coletado de um formulário real
-            const clientData = {
-                name: 'Cliente', // Substituir por dados reais do cliente
-                cpf: '12345678901', // Substituir por CPF real do cliente
-                email: 'cliente@exemplo.com', // Substituir por email real do cliente
-                phone: '11999999999' // Substituir por telefone real do cliente
-            };
-            
-            const transaction = await syncPay.createPixTransaction(plan.price, plan.description, clientData);
-            
-            // Fechar loading
-            if (typeof swal !== 'undefined') {
-                try {
-                    swal.close();
-                } catch (error) {
-                    console.warn('Erro ao fechar SweetAlert:', error);
-                }
-            } else {
-                const nativeLoading = document.getElementById('nativeLoading');
-                if (nativeLoading) {
-                    nativeLoading.remove();
-                }
-            }
-            
-            if (transaction) {
-                syncPay.showPixModal({
-                    pix_code: transaction.pix_code,
-                    amount: plan.price,
-                    id: transaction.id
-                });
-            }
-        } catch (error) {
-            console.error('Erro ao processar pagamento:', error);
-            
-            // Fechar loading em caso de erro
-            if (typeof swal !== 'undefined') {
-                try {
-                    swal.close();
-                } catch (e) {
-                    console.warn('Erro ao fechar SweetAlert:', e);
-                }
-            } else {
-                const nativeLoading = document.getElementById('nativeLoading');
-                if (nativeLoading) {
-                    nativeLoading.remove();
-                }
-            }
-            
-            alert('Erro ao processar pagamento: ' + error.message);
-        }
-    });
+    // Handlers dos botões 3 meses e 6 meses também movidos para pix-plan-buttons.js
 
     document.querySelectorAll('.action-button').forEach(button => {
         button.addEventListener('click', function() {
@@ -1326,6 +1119,12 @@ setTimeout(() => {
     
     <!-- Integração SyncPayments -->
     <script src="js/syncpay-integration.js"></script>
+    
+    <!-- Integração Universal de Pagamentos -->
+    <script src="js/universal-payment-integration.js"></script>
+    
+    <!-- Botões PIX com Gateway Universal -->
+    <script src="js/pix-plan-buttons.js"></script>
     
     <!-- Exemplo de uso (opcional - remover em produção) -->
     <script src="js/exemplo-uso-syncpay.js"></script>

--- a/public/js/gatewaySelector.js
+++ b/public/js/gatewaySelector.js
@@ -65,6 +65,19 @@ class GatewaySelector {
                 this.currentGateway = data.current;
                 this.updateUI();
                 this.showNotification(`Gateway alterado para ${gateway}`, 'success');
+                
+                // Disparar evento customizado para notificar outras partes do sistema
+                window.dispatchEvent(new CustomEvent('gateway-changed', {
+                    detail: { 
+                        gateway: this.currentGateway,
+                        previous: gateway 
+                    }
+                }));
+                
+                // Também atualizar a integração universal se disponível
+                if (window.universalPayment && typeof window.universalPayment.updateCurrentGateway === 'function') {
+                    window.universalPayment.updateCurrentGateway(this.currentGateway);
+                }
             } else {
                 this.showNotification('Erro ao alterar gateway', 'error');
             }

--- a/public/js/pix-plan-buttons.js
+++ b/public/js/pix-plan-buttons.js
@@ -1,7 +1,8 @@
 (function($){
     function attachPlanHandler(buttonId, planKey){
         $(buttonId).on('click', async function(){
-            if (!window.syncPay) {
+            // Verificar se a integração universal está disponível
+            if (!window.syncPay && !window.universalPayment) {
                 alert('Serviço de pagamento indisponível.');
                 return;
             }
@@ -14,14 +15,37 @@
             }
 
             try {
-                window.syncPay.showLoading();
-                const transaction = await window.syncPay.createPixTransaction(plan.price, plan.description);
+                // Usar a integração universal que detecta o gateway automaticamente
+                const paymentService = window.universalPayment || window.syncPay;
+                
+                // Mostrar loading com informação do gateway atual
+                if (paymentService.showLoading) {
+                    paymentService.showLoading();
+                }
+                
+                // Dados do cliente padrão (pode ser expandido para coletar dados reais)
+                const clientData = {
+                    name: 'Cliente',
+                    cpf: '12345678901',
+                    email: 'cliente@exemplo.com',
+                    phone: '11999999999'
+                };
+                
+                const transaction = await paymentService.createPixTransaction(plan.price, plan.description, clientData);
                 $(this).data('pixTransaction', transaction);
-                alert('PIX gerado com sucesso!');
+                
+                // Mostrar modal com o PIX gerado
+                if (paymentService.showPixModal && transaction.pix_code) {
+                    paymentService.showPixModal(transaction);
+                } else {
+                    alert(`PIX gerado com sucesso via ${transaction.gateway?.toUpperCase() || 'Gateway'}!`);
+                }
+                
             } catch (err) {
-                console.error(err);
-                alert('Erro ao gerar PIX.');
+                console.error('Erro ao gerar PIX:', err);
+                alert(`Erro ao gerar PIX: ${err.message}`);
             } finally {
+                // Fechar loading
                 if (typeof swal !== 'undefined') {
                     try {
                         swal.close();
@@ -36,8 +60,12 @@
     }
 
     $(function(){
-        attachPlanHandler('#btn-1-mes', 'monthly');
-        attachPlanHandler('#btn-3-meses', 'quarterly');
-        attachPlanHandler('#btn-6-meses', 'semestrial');
+        // Aguardar um pouco para garantir que as integrações estejam carregadas
+        setTimeout(() => {
+            attachPlanHandler('#btn-1-mes', 'monthly');
+            attachPlanHandler('#btn-3-meses', 'quarterly');
+            attachPlanHandler('#btn-6-meses', 'semestrial');
+            console.log('🔧 Handlers dos botões PIX configurados com integração universal');
+        }, 100);
     });
 })(jQuery);

--- a/public/js/universal-payment-integration.js
+++ b/public/js/universal-payment-integration.js
@@ -1,0 +1,275 @@
+/**
+ * Universal Payment Integration - Integração universal que funciona com qualquer gateway
+ * Detecta automaticamente o gateway selecionado e usa a API correspondente
+ */
+
+(function() {
+    'use strict';
+
+    /**
+     * Classe para integração universal de pagamentos
+     */
+    class UniversalPaymentIntegration {
+        constructor() {
+            this.currentGateway = 'syncpay'; // padrão
+            this.init();
+        }
+
+        async init() {
+            await this.loadCurrentGateway();
+        }
+
+        async loadCurrentGateway() {
+            try {
+                const response = await fetch('/api/gateways/current');
+                const data = await response.json();
+                if (data.success) {
+                    this.currentGateway = data.gateway;
+                    console.log(`🎯 Gateway atual carregado: ${this.currentGateway}`);
+                }
+            } catch (error) {
+                console.error('Erro ao carregar gateway atual:', error);
+                // Manter padrão syncpay em caso de erro
+            }
+        }
+
+        getCurrentGateway() {
+            return this.currentGateway;
+        }
+
+        async createPixTransaction(amount, description, clientData = null) {
+            try {
+                console.log(`💰 Criando transação PIX via ${this.currentGateway.toUpperCase()}...`);
+                
+                // Dados padrão do cliente se não fornecidos
+                const defaultClientData = {
+                    name: 'Cliente',
+                    cpf: '12345678901',
+                    email: 'cliente@exemplo.com',
+                    phone: '11999999999'
+                };
+
+                const finalClientData = { ...defaultClientData, ...clientData };
+
+                // Preparar dados para o endpoint unificado
+                const paymentData = {
+                    amount: parseFloat(amount),
+                    description: description,
+                    customer_name: finalClientData.name,
+                    customer_email: finalClientData.email,
+                    customer_document: finalClientData.cpf,
+                    customer_phone: finalClientData.phone
+                };
+
+                console.log('📤 Enviando dados do pagamento:', paymentData);
+
+                // Usar o endpoint unificado que já detecta o gateway
+                const response = await fetch('/api/payments/pix/create', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json'
+                    },
+                    body: JSON.stringify(paymentData)
+                });
+
+                console.log('📥 Resposta recebida:', response.status, response.statusText);
+
+                if (!response.ok) {
+                    const errorData = await response.json();
+                    throw new Error(`HTTP ${response.status}: ${errorData.message || response.statusText}`);
+                }
+
+                const data = await response.json();
+                console.log(`✅ Transação PIX criada via ${data.gateway.toUpperCase()}:`, data);
+
+                // Retornar dados padronizados independente do gateway
+                return {
+                    id: data.data.id || data.data.identifier || data.data.payment_id,
+                    pix_code: data.data.pix_code || data.data.qr_code,
+                    message: data.message,
+                    gateway: data.gateway,
+                    amount: amount,
+                    description: description
+                };
+
+            } catch (error) {
+                console.error(`❌ Erro ao criar transação PIX via ${this.currentGateway}:`, error);
+                throw error;
+            }
+        }
+
+        async getPaymentStatus(paymentId) {
+            try {
+                console.log(`🔍 Consultando status via ${this.currentGateway.toUpperCase()}...`);
+                
+                const response = await fetch(`/api/payments/${paymentId}/status`);
+                const data = await response.json();
+                
+                if (data.success) {
+                    return data.data;
+                } else {
+                    throw new Error(data.message || 'Erro ao consultar status');
+                }
+            } catch (error) {
+                console.error('Erro ao consultar status:', error);
+                throw error;
+            }
+        }
+
+        showLoading() {
+            console.log('🔄 Carregando...');
+            
+            // Criar loading nativo se SweetAlert não estiver disponível
+            if (typeof swal !== 'undefined') {
+                try {
+                    swal({
+                        title: 'Processando pagamento...',
+                        text: `Aguarde enquanto geramos seu código PIX via ${this.currentGateway.toUpperCase()}`,
+                        icon: 'info',
+                        buttons: false,
+                        closeOnClickOutside: false,
+                        closeOnEsc: false
+                    });
+                } catch (error) {
+                    console.warn('Erro ao mostrar loading SweetAlert:', error);
+                    this.showNativeLoading();
+                }
+            } else {
+                this.showNativeLoading();
+            }
+        }
+        
+        showNativeLoading() {
+            // Remover loading anterior se existir
+            const existingLoading = document.getElementById('nativeLoading');
+            if (existingLoading) {
+                existingLoading.remove();
+            }
+            
+            // Criar loading nativo
+            const loading = document.createElement('div');
+            loading.id = 'nativeLoading';
+            loading.style.cssText = `
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                background: rgba(0,0,0,0.7);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                z-index: 9999;
+                color: white;
+                font-size: 18px;
+                font-weight: 500;
+            `;
+            loading.innerHTML = `
+                <div style="text-align: center;">
+                    <div style="margin-bottom: 15px;">
+                        <div style="border: 4px solid #f3f3f3; border-top: 4px solid #F58170; border-radius: 50%; width: 40px; height: 40px; animation: spin 1s linear infinite; margin: 0 auto;"></div>
+                    </div>
+                    <div>Processando pagamento via ${this.currentGateway.toUpperCase()}...</div>
+                    <div style="font-size: 14px; margin-top: 5px; opacity: 0.8;">Aguarde enquanto geramos seu código PIX</div>
+                </div>
+                <style>
+                    @keyframes spin {
+                        0% { transform: rotate(0deg); }
+                        100% { transform: rotate(360deg); }
+                    }
+                </style>
+            `;
+            document.body.appendChild(loading);
+        }
+
+        showPixModal(data) {
+            // Usar o modal de pagamento personalizado
+            console.log(`💳 PIX gerado via ${data.gateway?.toUpperCase() || this.currentGateway.toUpperCase()}:`, data);
+            
+            try {
+                if (window.showPaymentModal && typeof window.showPaymentModal === 'function') {
+                    // Usar o modal personalizado
+                    window.showPaymentModal({
+                        pix_qr_code: data.pix_code,
+                        pix_copy_paste: data.pix_code,
+                        amount: data.amount || 0,
+                        identifier: data.id,
+                        status: 'pending',
+                        gateway: data.gateway || this.currentGateway
+                    });
+                } else if (window.showPixPopup && typeof window.showPixPopup === 'function') {
+                    // Usar popup alternativo
+                    window.showPixPopup({
+                        pix_code: data.pix_code,
+                        amount: data.amount || 0,
+                        id: data.id,
+                        gateway: data.gateway || this.currentGateway
+                    });
+                } else {
+                    // Fallback para alert simples
+                    alert(`PIX gerado com sucesso via ${(data.gateway || this.currentGateway).toUpperCase()}! Código: ${data.pix_code ? data.pix_code.substring(0, 50) + '...' : 'Não disponível'}`);
+                }
+            } catch (error) {
+                console.error('Erro ao mostrar modal PIX:', error);
+                // Fallback final
+                alert(`PIX gerado via ${(data.gateway || this.currentGateway).toUpperCase()}! Código: ${data.pix_code ? data.pix_code.substring(0, 50) + '...' : 'Não disponível'}`);
+            }
+        }
+
+        // Método para atualizar o gateway atual (chamado quando o usuário muda a seleção)
+        updateCurrentGateway(gateway) {
+            this.currentGateway = gateway;
+            console.log(`🔄 Gateway atualizado para: ${gateway}`);
+        }
+    }
+
+    // Instanciar a integração universal
+    const universalPayment = new UniversalPaymentIntegration();
+
+    // Expor para uso global - substituindo o window.syncPay existente
+    window.universalPayment = universalPayment;
+
+    // Manter compatibilidade com código existente criando um bridge
+    window.syncPay = {
+        showLoading: () => universalPayment.showLoading(),
+        createPixTransaction: (amount, description, clientData) => universalPayment.createPixTransaction(amount, description, clientData),
+        showPixModal: (data) => universalPayment.showPixModal(data)
+    };
+
+    // Listener para mudanças de gateway
+    document.addEventListener('DOMContentLoaded', () => {
+        // Aguardar um pouco para garantir que o gatewaySelector esteja carregado
+        setTimeout(() => {
+            // Escutar mudanças no seletor de gateway
+            const gatewaySelect = document.getElementById('gateway-select');
+            if (gatewaySelect) {
+                gatewaySelect.addEventListener('change', (e) => {
+                    universalPayment.updateCurrentGateway(e.target.value);
+                    console.log(`🎯 Gateway selecionado: ${e.target.value}`);
+                });
+            }
+
+            // Também escutar o evento customizado do gatewaySelector
+            window.addEventListener('gateway-changed', (event) => {
+                universalPayment.updateCurrentGateway(event.detail.gateway);
+                console.log(`🎯 Gateway alterado via evento: ${event.detail.gateway}`);
+            });
+
+            // Sincronizar com o gateway atual do gatewaySelector se disponível
+            if (window.gatewaySelector && typeof window.gatewaySelector.getCurrentGateway === 'function') {
+                const currentGateway = window.gatewaySelector.getCurrentGateway();
+                universalPayment.updateCurrentGateway(currentGateway);
+                console.log(`🔄 Sincronizado com gateway atual: ${currentGateway}`);
+            }
+        }, 200);
+    });
+
+    console.log('🔧 Universal Payment Integration carregado!');
+    console.log('📚 Funcionalidades:');
+    console.log('  - Detecção automática do gateway selecionado');
+    console.log('  - Compatibilidade com SyncPay e PushinPay');
+    console.log('  - Bridge para código existente (window.syncPay)');
+    console.log('  - Atualização automática quando gateway muda');
+
+})();


### PR DESCRIPTION
Implement universal PIX payment integration to dynamically use the selected gateway instead of always SyncPay.

The previous implementation of PIX generation buttons was hardcoded to use the SyncPay gateway, regardless of the user's selection. This change introduces a universal payment integration layer that detects the active gateway and routes PIX creation requests accordingly, ensuring the correct gateway is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-d16a70a5-89e0-4599-810f-f7edbfed1322">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d16a70a5-89e0-4599-810f-f7edbfed1322">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

