### PR TITLE
refactor: load secrets from app-config

### DIFF
--- a/app-config.json
+++ b/app-config.json
@@ -8,6 +8,10 @@
   "pushinpay": {
     "token": "36250|MPvURHE0gE6lqsPN0PtwDOUVISoLjSyvqYUvuDPi47f09b29"
   },
+  "webhook": {
+    "baseUrl": "https://seu-dominio.com",
+    "secret": "sua-chave-secreta-aqui"
+  },
   "model": {
     "name": "Arthur Lopes",
     "handle": "@arthur_lopes",

--- a/authService.js
+++ b/authService.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const { getConfig } = require('./loadConfig');
 
 let tokenCache = { access_token: null, expires_at: null };
 
@@ -14,12 +15,13 @@ async function getToken() {
 
   try {
     console.log('🔐 [authService] Obtendo novo token...');
-    
-                  const authData = {
-        client_id: process.env.SYNCPAY_CLIENT_ID || '708ddc0b-357d-4548-b158-615684caa616',
-        client_secret: process.env.SYNCPAY_CLIENT_SECRET || 'c08d40e5-3049-48c9-85c0-fd3cc6ca502c',
-        '01K1259MAXE0TNRXV2C2WQN2MV': 'auth_service_' + Date.now()
-      };
+
+    const cfg = getConfig();
+    const authData = {
+      client_id: cfg.syncpay?.clientId || '',
+      client_secret: cfg.syncpay?.clientSecret || '',
+      '01K1259MAXE0TNRXV2C2WQN2MV': 'auth_service_' + Date.now()
+    };
 
     const { data } = await axios.post(
       'https://api.syncpayments.com.br/api/partner/v1/auth-token',

--- a/configManager.js
+++ b/configManager.js
@@ -20,6 +20,10 @@ async function main() {
   cfg.syncpay.clientSecret = await ask('SyncPay Client Secret', cfg.syncpay.clientSecret);
   cfg.pushinpay.token = await ask('PushinPay Token', cfg.pushinpay.token);
 
+  cfg.webhook = cfg.webhook || { baseUrl: 'https://seu-dominio.com', secret: 'sua-chave-secreta-aqui' };
+  cfg.webhook.baseUrl = await ask('Webhook base URL', cfg.webhook.baseUrl);
+  cfg.webhook.secret = await ask('Webhook secret', cfg.webhook.secret);
+
   cfg.model.name = await ask('Model name', cfg.model.name);
   cfg.model.handle = await ask('Model @', cfg.model.handle);
   cfg.model.bio = await ask('Model bio', cfg.model.bio);

--- a/controller/config.js
+++ b/controller/config.js
@@ -60,17 +60,17 @@ const PLANS = dynamic.plans || {};
 // ============================
 const WEBHOOK_CONFIG = {
     // URL base para receber webhooks (configure conforme seu domínio)
-    BASE_URL: process.env.WEBHOOK_BASE_URL || 'https://seu-dominio.com',
-    
+    BASE_URL: dynamic.webhook?.baseUrl || 'https://seu-dominio.com',
+
     // Endpoints de webhook
     ENDPOINTS: {
         syncpay: '/webhook/syncpay',
         pushinpay: '/webhook/pushinpay'
     },
-    
+
     // Configurações de segurança
     VALIDATE_SIGNATURE: true,
-    SECRET_KEY: process.env.WEBHOOK_SECRET || 'sua-chave-secreta-aqui' // ← ALTERE AQUI
+    SECRET_KEY: dynamic.webhook?.secret || 'sua-chave-secreta-aqui'
 };
 
 // ============================

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "axios": "^1.6.8",
         "cors": "^2.8.5",
-        "dotenv": "^17.2.1",
         "express": "^4.18.2",
         "node-fetch": "^2.6.7"
       },
@@ -306,18 +305,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "config": "node configManager.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
@@ -19,7 +20,6 @@
   "dependencies": {
     "axios": "^1.6.8",
     "cors": "^2.8.5",
-    "dotenv": "^17.2.1",
     "express": "^4.18.2",
     "node-fetch": "^2.6.7"
   },

--- a/pushinpayApi.js
+++ b/pushinpayApi.js
@@ -1,12 +1,14 @@
 const axios = require('axios');
+const { getConfig } = require('./loadConfig');
 
-// Token deve ser configurado via variável de ambiente por segurança
-const PUSHINPAY_TOKEN = process.env.PUSHINPAY_TOKEN || '36250|MPvURHE0gE6lqsPN0PtwDOUVISoLjSyvqYUvuDPi47f09b29';
+// Carregar configurações dinâmicas
+const cfg = getConfig();
+const PUSHINPAY_TOKEN = cfg.pushinpay?.token || '';
 
 // URLs conforme documentação oficial
 const API_BASE_PROD = 'https://api.pushinpay.com.br';
 const API_BASE_SANDBOX = 'https://api-sandbox.pushinpay.com.br';
-const API_BASE = process.env.PUSHINPAY_ENVIRONMENT === 'sandbox' ? API_BASE_SANDBOX : API_BASE_PROD;
+const API_BASE = cfg.environment === 'sandbox' ? API_BASE_SANDBOX : API_BASE_PROD;
 
 async function pushinpayGet(endpoint, config = {}) {
   return axios.get(`${API_BASE}${endpoint}`, {
@@ -167,11 +169,14 @@ async function listPayments(filters = {}) {
 
 // Função para verificar configuração e ambiente
 function getEnvironmentInfo() {
+  const cfg = getConfig();
+  const token = cfg.pushinpay?.token;
+  const environment = cfg.environment || 'production';
   return {
-    environment: process.env.PUSHINPAY_ENVIRONMENT || 'production',
-    api_base: API_BASE,
-    token_configured: !!PUSHINPAY_TOKEN,
-    token_preview: PUSHINPAY_TOKEN ? `${PUSHINPAY_TOKEN.substring(0, 10)}...` : 'Não configurado'
+    environment,
+    api_base: environment === 'sandbox' ? API_BASE_SANDBOX : API_BASE_PROD,
+    token_configured: !!token,
+    token_preview: token ? `${token.substring(0, 10)}...` : 'Não configurado'
   };
 }
 

--- a/server.js
+++ b/server.js
@@ -1,4 +1,3 @@
-require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
@@ -82,14 +81,15 @@ app.post('/api/auth-token', async (req, res) => {
         const extraField = req.body['01K1259MAXE0TNRXV2C2WQN2MV'] || 'valor';
         
         // Verificar se as credenciais estão disponíveis
-        const clientId = process.env.SYNCPAY_CLIENT_ID || '708ddc0b-357d-4548-b158-615684caa616';
-        const clientSecret = process.env.SYNCPAY_CLIENT_SECRET || 'c08d40e5-3049-48c9-85c0-fd3cc6ca502c';
-        
+        const cfg = getConfig();
+        const clientId = cfg.syncpay?.clientId;
+        const clientSecret = cfg.syncpay?.clientSecret;
+
         if (!clientId || !clientSecret) {
             console.error('[Auth] Credenciais não configuradas');
             return res.status(500).json({
                 message: 'Credenciais da API não configuradas',
-                error: 'SYNCPAY_CLIENT_ID ou SYNCPAY_CLIENT_SECRET não definidos'
+                error: 'syncpay.clientId ou syncpay.clientSecret não definidos'
             });
         }
         
@@ -450,16 +450,17 @@ app.get('/api/gateways/test', (req, res) => {
         const gateways = paymentGateway.getAvailableGateways();
         const currentGateway = paymentGateway.getCurrentGateway();
         
+        const cfg = getConfig();
         res.json({
             success: true,
             message: 'Configuração dos gateways',
             current_gateway: currentGateway,
             gateways: gateways,
-            environment_vars: {
-                pushinpay_token: process.env.PUSHINPAY_TOKEN ? 'Configurado' : 'Não configurado',
-                pushinpay_environment: process.env.PUSHINPAY_ENVIRONMENT || 'production (padrão)',
-                syncpay_client_id: process.env.SYNCPAY_CLIENT_ID ? 'Configurado' : 'Usando padrão',
-                syncpay_client_secret: process.env.SYNCPAY_CLIENT_SECRET ? 'Configurado' : 'Usando padrão'
+            config_status: {
+                pushinpay_token: cfg.pushinpay?.token ? 'Configurado' : 'Não configurado',
+                pushinpay_environment: cfg.environment || 'production',
+                syncpay_client_id: cfg.syncpay?.clientId ? 'Configurado' : 'Não configurado',
+                syncpay_client_secret: cfg.syncpay?.clientSecret ? 'Configurado' : 'Não configurado'
             }
         });
     } catch (error) {

--- a/webhookHandler.js
+++ b/webhookHandler.js
@@ -5,10 +5,12 @@
 
 const express = require('express');
 const crypto = require('crypto');
+const { getConfig } = require('./loadConfig');
 
 class WebhookHandler {
     constructor() {
-        this.webhookSecret = process.env.SYNCPAY_WEBHOOK_SECRET || 'default_secret';
+        const cfg = getConfig();
+        this.webhookSecret = cfg.webhook?.secret || 'default_secret';
     }
 
     /**


### PR DESCRIPTION
## Summary
- read payment credentials and webhook secret from app-config.json
- expose interactive `npm run config` helper
- drop dotenv usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b75cb259e8832a9d792ad68aa3eec2