### PR TITLE
feat: make redirect URL configurable

### DIFF
--- a/app-config.json
+++ b/app-config.json
@@ -39,5 +39,6 @@
       "price": 119.43,
       "description": "Assinatura semestral"
     }
-  }
+  },
+  "redirectUrl": "https://www.youtube.com/watch?v=KWiSv44OYI0&list=RDKWiSv44OYI0&start_radio=1"
 }

--- a/configManager.js
+++ b/configManager.js
@@ -24,6 +24,8 @@ async function main() {
   cfg.webhook.baseUrl = await ask('Webhook base URL', cfg.webhook.baseUrl);
   cfg.webhook.secret = await ask('Webhook secret', cfg.webhook.secret);
 
+  cfg.redirectUrl = await ask('Redirect URL', cfg.redirectUrl || 'https://www.youtube.com/watch?v=KWiSv44OYI0&list=RDKWiSv44OYI0&start_radio=1');
+
   cfg.model.name = await ask('Model name', cfg.model.name);
   cfg.model.handle = await ask('Model @', cfg.model.handle);
   cfg.model.bio = await ask('Model bio', cfg.model.bio);

--- a/public/js/payment-modal.js
+++ b/public/js/payment-modal.js
@@ -371,7 +371,8 @@ class PaymentModal {
                         setTimeout(() => {
                             this.close();
                             this.showToast('Pagamento realizado com sucesso!', 'success');
-                            window.location.href = 'https://www.youtube.com/watch?v=KWiSv44OYI0&list=RDKWiSv44OYI0&start_radio=1';
+                            const redirectUrl = (window.APP_CONFIG && window.APP_CONFIG.redirectUrl) || 'https://www.youtube.com/watch?v=KWiSv44OYI0&list=RDKWiSv44OYI0&start_radio=1';
+                            window.location.href = redirectUrl;
                         }, 3000);
 
                     } else if (status.status === 'expired' || status.status === 'cancelled') {

--- a/server.js
+++ b/server.js
@@ -67,7 +67,8 @@ app.get('/api/config', (req, res) => {
         plans: cfg.plans,
         gateway: cfg.gateway,
         syncpay: cfg.syncpay,
-        pushinpay: cfg.pushinpay
+        pushinpay: cfg.pushinpay,
+        redirectUrl: cfg.redirectUrl
     });
 });
 


### PR DESCRIPTION
## Summary
- add `redirectUrl` to app-config and expose it through `/api/config`
- allow editing redirect URL via config manager
- use configurable redirect URL after successful payment

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b761e691d0832a97d3452bc1d60885