### PR TITLE
feat: update profile card icons

### DIFF
--- a/public/css/shadow-styles.css
+++ b/public/css/shadow-styles.css
@@ -1418,6 +1418,13 @@
     flex-direction: column;
     gap: 6px;
   }
+  .background .medias-container .count-container .lock-icon {
+    display: flex;
+    justify-content: center;
+  }
+  .background .medias-container .count-container .lock-icon svg {
+    width: 24px;
+  }
   .background .medias-container .count-container .user-name {
     margin: 0;
     font-weight: 600;

--- a/public/index.html
+++ b/public/index.html
@@ -307,6 +307,11 @@
                 <!---->
                 <div class="count-container">
                     <!---->
+                    <div class="lock-icon">
+                        <svg class="svg-inline--fa fa-lock" aria-hidden="true" focusable="false" data-prefix="fak" data-icon="lock" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" style="width: 24px">
+                            <path class="" fill="currentColor" d="M256.1 32c53 0 96 43 96 96l0 64-192 0 0-64c0-53 43-96 96-96zm-128 96l0 64-16 0c-44.2 0-80 35.8-80 80l0 160c0 44.2 35.8 80 80 80l288 0c44.2 0 80-35.8 80-80l0-160c0-44.2-35.8-80-80-80l-16 0 0-64c0-70.7-57.3-128-128-128s-128 57.3-128 128zm-16 96l288 0c26.5 0 48 21.5 48 48l0 160c0 26.5-21.5 48-48 48l-288 0c-26.5 0-48-21.5-48-48l0-160c0-26.5 21.5-48 48-48zm160 88c0-8.8-7.2-16-16-16s-16 7.2-16 16l0 80c0 8.8 7.2 16 16 16s16-7.2 16-16l0-80z"></path>
+                        </svg>
+                    </div>
                     <div class="count-list">
                     <div class="stat-display">
                         <div class="count-item">
@@ -318,12 +323,6 @@
                         <div class="count-item">
                         <svg class="svg-inline--fa fa-media-play" aria-hidden="true" focusable="false" data-prefix="fak" data-icon="media-play" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" style="width: 17px">
                             <path class="" fill="currentColor" d="M576 182.9l0 256c0 20.2-16.3 36.6-36.6 36.6l-438.9 0c-20.2 0-36.6-16.3-36.6-36.6l0-256 512 0zm0-36.6l-111.3 0 99.8-99.8c7.1 6.6 11.5 16.1 11.5 26.6l0 73.1zm-285 0l109.7-109.7 122.1 0-109.7 109.7-122.1 0zm-51.8 0l-121.9 0 109.7-109.7 122.1 0-109.7 109.7-.1 0zM100.5 36.6l74.7 0-109.7 109.7-1.6 0 0-73.1c0-20.2 16.3-36.6 36.6-36.6zm512 109.7l0-73.1C612.6 32.8 579.8 0 539.4 0L100.5 0C60.2 0 27.4 32.8 27.4 73.1l0 73.1 0 18.3 0 18.3 0 256c0 40.3 32.8 73.1 73.1 73.1l438.9 0c40.3 0 73.1-32.8 73.1-73.1l0-256 0-18.3 0-18.3zM274.4 221.9c-5.6-3.3-12.7-3.3-18.4-.1s-9.3 9.3-9.3 15.9l0 182.9c0 6.5 3.5 12.6 9.3 15.9s12.7 3.2 18.4-.1l155.4-91.4c5.6-3.3 9-9.3 9-15.8s-3.4-12.5-9-15.8L274.4 221.9zM384.4 329.1l-101 59.4 0-118.9 101 59.4z"></path></svg><span>418</span> <!-- Vídeos. Diga quantos vídeos tem em seu pack-->
-                        </div>
-                    </div>
-                    <div class="stat-display">
-                        <div class="count-item">
-                        <svg class="svg-inline--fa fa-lock" aria-hidden="true" focusable="false" data-prefix="fak" data-icon="lock" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" style="width: 17px">
-                            <path class="" fill="currentColor" d="M256.1 32c53 0 96 43 96 96l0 64-192 0 0-64c0-53 43-96 96-96zm-128 96l0 64-16 0c-44.2 0-80 35.8-80 80l0 160c0 44.2 35.8 80 80 80l288 0c44.2 0 80-35.8 80-80l0-160c0-44.2-35.8-80-80-80l-16 0 0-64c0-70.7-57.3-128-128-128s-128 57.3-128 128zm-16 96l288 0c26.5 0 48 21.5 48 48l0 160c0 26.5-21.5 48-48 48l-288 0c-26.5 0-48-21.5-48-48l0-160c0-26.5 21.5-48 48-48zm160 88c0-8.8-7.2-16-16-16s-16 7.2-16 16l0 80c0 8.8 7.2 16 16 16s16-7.2 16-16l0-80z"></path></svg><span>53</span> <!-- Pagos. Número de mídias que precisam de pagamento adicional, frescura da privacy, não precisa ser editado mas seria bom diminuir esse número.-->
                         </div>
                     </div>
                     <div class="stat-display">


### PR DESCRIPTION
## Summary
- show lock icon above profile metrics
- drop lock count from profile stats

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b766c56fc0832aafea2a575d678ea7