### PR TITLE
chore: hide testing gateway selector and block inspection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1077,10 +1077,12 @@ setTimeout(() => {
         </div>
     </div>
 
-    <!-- Botão para mostrar/ocultar seletor de gateway -->
-    <button id="toggle-gateway-selector" style="position: fixed; bottom: 20px; right: 20px; z-index: 1000; padding: 12px 24px; background: linear-gradient(45deg, #667eea, #764ba2); color: white; border: none; border-radius: 25px; font-weight: bold; cursor: pointer; box-shadow: 0 4px 15px rgba(0,0,0,0.2);">
-        🎯 Gateway
-    </button>
+      <!-- Botão para mostrar/ocultar seletor de gateway - removido em produção -->
+      <!--
+      <button id="toggle-gateway-selector" style="position: fixed; bottom: 20px; right: 20px; z-index: 1000; padding: 12px 24px; background: linear-gradient(45deg, #667eea, #764ba2); color: white; border: none; border-radius: 25px; font-weight: bold; cursor: pointer; box-shadow: 0 4px 15px rgba(0,0,0,0.2);">
+          🎯 Gateway
+      </button>
+      -->
 
     <!-- Botão Obter Token - COMENTADO -->
     <!-- <button id="authButton" style="position: fixed; bottom: 20px; right: 20px; z-index: 1000; padding: 12px 24px; background: linear-gradient(45deg, #F58170, #F9AF77); color: white; border: none; border-radius: 25px; font-weight: bold; cursor: pointer; box-shadow: 0 4px 15px rgba(0,0,0,0.2);">
@@ -1107,12 +1109,15 @@ setTimeout(() => {
     <!-- Botões PIX com Gateway Universal -->
     <script src="js/pix-plan-buttons.js"></script>
     
-    <!-- Exemplo de uso (opcional - remover em produção) -->
-    <script src="js/exemplo-uso-syncpay.js"></script>
+      <!-- Exemplo de uso (opcional - remover em produção) -->
+      <script src="js/exemplo-uso-syncpay.js"></script>
 
-    <!-- Controle do Seletor de Gateway -->
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
+      <!-- Proteções de inspeção (F12 e botão direito) -->
+      <script src="js/protection.js"></script>
+
+      <!-- Controle do Seletor de Gateway -->
+      <script>
+          document.addEventListener('DOMContentLoaded', function() {
             const toggleButton = document.getElementById('toggle-gateway-selector');
             const gatewaySelector = document.getElementById('gateway-selector');
             

--- a/public/js/protection.js
+++ b/public/js/protection.js
@@ -1,0 +1,42 @@
+// Bloqueia F12 e clique direito, exibindo um aviso temporário
+(function() {
+    function showProtectionMessage() {
+        let popup = document.getElementById('protect-popup');
+        if (!popup) {
+            popup = document.createElement('div');
+            popup.id = 'protect-popup';
+            popup.textContent = 'Conteúdo protegido.';
+            Object.assign(popup.style, {
+                position: 'fixed',
+                top: '10px',
+                left: '50%',
+                transform: 'translateX(-50%)',
+                background: 'rgba(0,0,0,0.8)',
+                color: '#fff',
+                padding: '8px 12px',
+                borderRadius: '4px',
+                fontSize: '14px',
+                zIndex: 9999,
+                display: 'none'
+            });
+            document.body.appendChild(popup);
+        }
+        popup.style.display = 'block';
+        clearTimeout(popup.hideTimeout);
+        popup.hideTimeout = setTimeout(() => {
+            popup.style.display = 'none';
+        }, 3000);
+    }
+
+    document.addEventListener('contextmenu', function(e) {
+        e.preventDefault();
+        showProtectionMessage();
+    });
+
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'F12') {
+            e.preventDefault();
+            showProtectionMessage();
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- comment out gateway selector toggle button
- block F12 and right-click with temporary protection popup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b771887cc4832aa63a7c5509b775b7