### PR TITLE
Remove extra PIX generation message

### DIFF
--- a/public/js/syncpay-integration.js
+++ b/public/js/syncpay-integration.js
@@ -741,7 +741,6 @@
                 try {
                     swal({
                         title: 'Processando pagamento...',
-                        text: 'Aguarde enquanto geramos seu código PIX',
                         icon: 'info',
                         buttons: false,
                         closeOnClickOutside: false,
@@ -787,7 +786,6 @@
                         <div style="border: 4px solid #f3f3f3; border-top: 4px solid #F58170; border-radius: 50%; width: 40px; height: 40px; animation: spin 1s linear infinite; margin: 0 auto;"></div>
                     </div>
                     <div>Processando pagamento...</div>
-                    <div style="font-size: 14px; margin-top: 5px; opacity: 0.8;">Aguarde enquanto geramos seu código PIX</div>
                 </div>
                 <style>
                     @keyframes spin {

--- a/public/js/universal-payment-integration.js
+++ b/public/js/universal-payment-integration.js
@@ -125,7 +125,6 @@
                 try {
                     swal({
                         title: 'Processando pagamento...',
-                        text: `Aguarde enquanto geramos seu código PIX via ${this.currentGateway.toUpperCase()}`,
                         icon: 'info',
                         buttons: false,
                         closeOnClickOutside: false,
@@ -170,8 +169,7 @@
                     <div style="margin-bottom: 15px;">
                         <div style="border: 4px solid #f3f3f3; border-top: 4px solid #F58170; border-radius: 50%; width: 40px; height: 40px; animation: spin 1s linear infinite; margin: 0 auto;"></div>
                     </div>
-                    <div>Processando pagamento via ${this.currentGateway.toUpperCase()}...</div>
-                    <div style="font-size: 14px; margin-top: 5px; opacity: 0.8;">Aguarde enquanto geramos seu código PIX</div>
+                    <div>Processando pagamento...</div>
                 </div>
                 <style>
                     @keyframes spin {


### PR DESCRIPTION
## Summary
- Simplify PIX loading modal by removing secondary "Aguarde" text
- Keep only the primary "Processando pagamento..." message in fallback loader

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b77481d390832a8f148bd4434359b1