### PR TITLE
Add configurable mobile QR code generation

### DIFF
--- a/app-config.json
+++ b/app-config.json
@@ -1,6 +1,7 @@
 {
   "gateway": "pushinpay",
   "environment": "production",
+  "generateQRCodeOnMobile": false,
   "syncpay": {
     "clientId": "708ddc0b-357d-4548-b158-615684caa616",
     "clientSecret": "c08d40e5-3049-48c9-85c0-fd3cc6ca502c"

--- a/configManager.js
+++ b/configManager.js
@@ -16,6 +16,8 @@ async function main() {
 
   cfg.gateway = await ask('Gateway (syncpay/pushinpay)', cfg.gateway);
   cfg.environment = await ask('Environment (production/sandbox)', cfg.environment);
+  const defaultMobileQR = cfg.generateQRCodeOnMobile ? 'true' : 'false';
+  cfg.generateQRCodeOnMobile = (await ask('Generate QR Code on mobile? (true/false)', defaultMobileQR)).toLowerCase() === 'true';
   cfg.syncpay.clientId = await ask('SyncPay Client ID', cfg.syncpay.clientId);
   cfg.syncpay.clientSecret = await ask('SyncPay Client Secret', cfg.syncpay.clientSecret);
   cfg.pushinpay.token = await ask('PushinPay Token', cfg.pushinpay.token);

--- a/public/js/payment-modal.js
+++ b/public/js/payment-modal.js
@@ -190,8 +190,9 @@ class PaymentModal {
             }
 
             const isMobile = window.innerWidth <= 768;
+            const allowMobileQR = window.APP_CONFIG ? window.APP_CONFIG.generateQRCodeOnMobile : false;
             if (qrContainer) {
-                if (isMobile) {
+                if (isMobile && !allowMobileQR) {
                     qrContainer.style.display = 'none';
                     return;
                 }

--- a/server.js
+++ b/server.js
@@ -68,7 +68,8 @@ app.get('/api/config', (req, res) => {
         gateway: cfg.gateway,
         syncpay: cfg.syncpay,
         pushinpay: cfg.pushinpay,
-        redirectUrl: cfg.redirectUrl
+        redirectUrl: cfg.redirectUrl,
+        generateQRCodeOnMobile: cfg.generateQRCodeOnMobile
     });
 });
 


### PR DESCRIPTION
## Summary
- allow toggling QR code generation on mobile via `generateQRCodeOnMobile` in `app-config.json`
- expose the new setting through `/api/config`
- respect configuration in payment modal and update config manager prompt

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b775cfb9fc832a99ac95f49d13c26c